### PR TITLE
Use project name without hyphens as add-on ID

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ java {
 }
 
 zapAddOn {
+    addOnId.set(project.name.replace("-", ""))
     addOnName.set("FuzzDB Web Backdoors")
     addOnStatus.set(AddOnStatus.RELEASE)
     zapVersion.set("2.5.0")


### PR DESCRIPTION
The hyphens are not supported in the ID.