### PR TITLE
Update ZAP and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased
+## [1] - 2019-06-27
 
 First version.
+
+[1]: https://github.com/zaproxy/fuzzdb-web-backdoors/releases/v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ zapAddOn {
     addOnId.set(project.name.replace("-", ""))
     addOnName.set("FuzzDB Web Backdoors")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.5.0")
+    zapVersion.set("2.8.0")
 
     releaseLink.set("https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")
     unreleasedLink.set("https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v@CURRENT_VERSION@...HEAD")


### PR DESCRIPTION
Update minimum ZAP version to 2.8.0.
Update changelog with release date and link to tag.