### PR TITLE
Update add-on plugin and help links, tweak HelpSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+ - Add repo URL, shown in the marketplace and Manage Add-ons dialogue.
 
+### Changed
+ - Change info URL to link to the online help page.
 
 ## [1] - 2019-06-27
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 fuzzdb-web-backdoors
 ====================
 
-A ZAP add-on with FuzzDB web backdoors, split from the main add-on to avoid issues with AVs.
+A ZAP add-on with [FuzzDB] web backdoors, split from the main FuzzDB add-on to avoid issues with AVs.
+
+[FuzzDB]: https://github.com/fuzzdb-project/fuzzdb/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ import org.zaproxy.gradle.addon.misc.ExtractLatestChangesFromChangelog
 plugins {
     `java-library`
     eclipse
-    id("org.zaproxy.add-on") version "0.2.0"
+    id("org.zaproxy.add-on") version "0.3.0"
 }
 
 eclipse {
@@ -40,7 +40,8 @@ zapAddOn {
 
     manifest {
         author.set("ZAP Dev Team")
-        url.set("https://github.com/fuzzdb-project/fuzzdb/")
+        url.set("https://zaproxy.org/docs/desktop/addons/fuzzdb-web-backdoors/")
+        repo.set("https://github.com/zaproxy/fuzzdb-web-backdoors/")
         changesFile.set(tasks.named<ConvertMarkdownToHtml>("generateManifestChanges").flatMap { it.html })
 
         helpSet {

--- a/src/main/javahelp/help/contents/intro.html
+++ b/src/main/javahelp/help/contents/intro.html
@@ -8,7 +8,7 @@ FuzzDB Web Backdoors
 </HEAD>
 <BODY BGCOLOR="#ffffff">
 <H1>FuzzDB Web Backdoors</H1>
-FuzzDB web backdoors which can be used with the ZAP fuzzer.
+<a href="https://github.com/fuzzdb-project/fuzzdb/">FuzzDB</a> web backdoors which can be used with the ZAP fuzzer.
 
 </BODY>
 </HTML>

--- a/src/main/javahelp/help/helpset.hs
+++ b/src/main/javahelp/help/helpset.hs
@@ -6,7 +6,7 @@
   <title>FuzzDB Web Backdoors Add-On</title>
 
   <maps>
-     <homeID>top</homeID>
+     <homeID>fuzzdb-web-backdoors</homeID>
      <mapref location="map.jhm"/>
   </maps>
 


### PR DESCRIPTION
Update add-on plugin to 0.3.0:
 - Specify the repo URL in the add-on manifest.
 - Change info URL to point to the help page.

Link to FuzzDB from the README and help.
Change HelpSet to link to the main help page.