### PR TITLE
Update ZAP and prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,17 @@ All notable changes to this add-on will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [2] - 2020-01-30
 ### Added
  - Add repo URL, shown in the marketplace and Manage Add-ons dialogue.
 
 ### Changed
  - Change info URL to link to the online help page.
+ - Change minimum ZAP version to 2.9.0.
 
 ## [1] - 2019-06-27
 
 First version.
 
-[Unreleased]: https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v1...HEAD
+[2]: https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v1...v2
 [1]: https://github.com/zaproxy/fuzzdb-web-backdoors/releases/v1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ zapAddOn {
     addOnId.set(project.name.replace("-", ""))
     addOnName.set("FuzzDB Web Backdoors")
     addOnStatus.set(AddOnStatus.RELEASE)
-    zapVersion.set("2.8.0")
+    zapVersion.set("2.9.0")
 
     releaseLink.set("https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v@PREVIOUS_VERSION@...v@CURRENT_VERSION@")
     unreleasedLink.set("https://github.com/zaproxy/fuzzdb-web-backdoors/compare/v@CURRENT_VERSION@...HEAD")


### PR DESCRIPTION
Update minimum ZAP version to 2.9.0.
Update changelog with release date and link to tag.