### PR TITLE
Do not set the background colour of help page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this add-on will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-
+### Changed
+- Do not set the background colour of the help page.
 
 ## [2] - 2020-01-30
 ### Added

--- a/src/main/javahelp/help/contents/intro.html
+++ b/src/main/javahelp/help/contents/intro.html
@@ -6,7 +6,7 @@
 FuzzDB Web Backdoors
 </TITLE>
 </HEAD>
-<BODY BGCOLOR="#ffffff">
+<BODY>
 <H1>FuzzDB Web Backdoors</H1>
 <a href="https://github.com/fuzzdb-project/fuzzdb/">FuzzDB</a> web backdoors which can be used with the ZAP fuzzer.
 


### PR DESCRIPTION
Let the UI set the colour of the background, the help page doesn't
require the background to be white.

Part of zaproxy/zaproxy#5542.